### PR TITLE
7주차 과제제출

### DIFF
--- a/src/main/java/org/sopt/article/controller/ArticleController.java
+++ b/src/main/java/org/sopt/article/controller/ArticleController.java
@@ -3,6 +3,7 @@ package org.sopt.article.controller;
 import org.sopt.article.domain.Article;
 import org.sopt.article.dto.request.PostArticleRequestDto;
 import org.sopt.article.dto.response.GetArticleDetailResponseDto;
+import org.sopt.article.dto.response.GetArticlePreviewResponseDto;
 import org.sopt.article.dto.response.GetArticleResponseDto;
 import org.sopt.article.service.ArticleService;
 import org.sopt.comment.domain.Comment;
@@ -41,10 +42,10 @@ public class ArticleController {
 
     // 전체 조회
     @GetMapping
-    public ResponseEntity<List<GetArticleResponseDto>> getAllArticles() {
-        List<GetArticleResponseDto> articles = articleService.findAllArticles()
+    public ResponseEntity<List<GetArticlePreviewResponseDto>> getAllArticles() {
+        List<GetArticlePreviewResponseDto> articles = articleService.findAllArticles()
                 .stream()
-                .map(GetArticleResponseDto::from)
+                .map(GetArticlePreviewResponseDto::from)
                 .toList();
         return ResponseEntity.ok(articles);
     }

--- a/src/main/java/org/sopt/article/controller/ArticleController.java
+++ b/src/main/java/org/sopt/article/controller/ArticleController.java
@@ -1,11 +1,12 @@
 package org.sopt.article.controller;
 
-import lombok.RequiredArgsConstructor;
 import org.sopt.article.domain.Article;
 import org.sopt.article.dto.request.PostArticleRequestDto;
+import org.sopt.article.dto.response.GetArticleDetailResponseDto;
 import org.sopt.article.dto.response.GetArticleResponseDto;
 import org.sopt.article.service.ArticleService;
-import org.sopt.member.service.MemberService;
+import org.sopt.comment.domain.Comment;
+import org.sopt.comment.service.CommentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,9 +17,11 @@ import java.util.List;
 public class ArticleController {
 
     private final ArticleService articleService;
+    private final CommentService commentService;
 
-    public ArticleController(ArticleService articleService) {
+    public ArticleController(ArticleService articleService, CommentService commentService) {
         this.articleService = articleService;
+        this.commentService = commentService;
     }
 
     // 아티클 생성
@@ -30,9 +33,10 @@ public class ArticleController {
 
     // 단일 조회
     @GetMapping("/{id}")
-    public ResponseEntity<GetArticleResponseDto> getArticle(@PathVariable Long id) {
+    public ResponseEntity<GetArticleDetailResponseDto> getArticle(@PathVariable Long id) {
         Article article = articleService.findArticleById(id);
-        return ResponseEntity.ok(GetArticleResponseDto.from(article));
+        List<Comment> commentList = commentService.findAllCommentsByPostId(id);
+        return ResponseEntity.ok(GetArticleDetailResponseDto.from(article, commentList));
     }
 
     // 전체 조회

--- a/src/main/java/org/sopt/article/dto/response/GetArticleDetailResponseDto.java
+++ b/src/main/java/org/sopt/article/dto/response/GetArticleDetailResponseDto.java
@@ -1,0 +1,28 @@
+package org.sopt.article.dto.response;
+
+import org.sopt.article.domain.Article;
+import org.sopt.comment.domain.Comment;
+
+import java.util.List;
+
+public record GetArticleDetailResponseDto(
+        Long id,
+        String title,
+        String content,
+        String tag,
+        Long authorId,
+        String created,
+        List<Comment> commentList
+) {
+    public static GetArticleDetailResponseDto from(Article article, List<Comment> commentList) {
+        return new GetArticleDetailResponseDto(
+                article.getId(),
+                article.getTitle(),
+                article.getContent(),
+                article.getTag().name(),
+                article.getAuthorId(),
+                article.getCreated().toString(),
+                commentList
+        );
+    }
+}

--- a/src/main/java/org/sopt/article/dto/response/GetArticlePreviewResponseDto.java
+++ b/src/main/java/org/sopt/article/dto/response/GetArticlePreviewResponseDto.java
@@ -1,0 +1,24 @@
+package org.sopt.article.dto.response;
+
+import org.sopt.article.domain.Article;
+import org.sopt.comment.domain.Comment;
+
+import java.util.List;
+
+public record GetArticlePreviewResponseDto(
+        Long id,
+        String title,
+        String tag,
+        Long authorId,
+        String created
+) {
+    public static GetArticlePreviewResponseDto from(Article article) {
+        return new GetArticlePreviewResponseDto(
+                article.getId(),
+                article.getTitle(),
+                article.getTag().name(),
+                article.getAuthorId(),
+                article.getCreated().toString()
+        );
+    }
+}

--- a/src/main/java/org/sopt/comment/controller/CommentController.java
+++ b/src/main/java/org/sopt/comment/controller/CommentController.java
@@ -23,15 +23,15 @@ public class CommentController {
     // 댓글 생성
     @PostMapping
     public ResponseEntity<GetCommentResponseDto> createComment(@RequestBody PostCommentRequestDto requestDto) {
-        Comment Comment = commentService.createComment(requestDto);
-        return ResponseEntity.ok(GetCommentResponseDto.from(Comment));
+        Comment comment = commentService.createComment(requestDto);
+        return ResponseEntity.ok(GetCommentResponseDto.from(comment));
     }
 
     // 단일 조회
     @GetMapping("/{id}")
     public ResponseEntity<GetCommentResponseDto> getComment(@PathVariable Long id) {
-        Comment Comment = commentService.findCommentById(id);
-        return ResponseEntity.ok(GetCommentResponseDto.from(Comment));
+        Comment comment = commentService.findCommentById(id);
+        return ResponseEntity.ok(GetCommentResponseDto.from(comment));
     }
 
     // 글 아이디 기준으로 전체 조회
@@ -48,8 +48,8 @@ public class CommentController {
     @PatchMapping("/{id}")
     public ResponseEntity<GetCommentResponseDto> updateComment(@RequestBody UpdateCommentRequestDto requestDto,
                                                                @PathVariable Long id) {
-        Comment Comment = commentService.updateComment(id, requestDto.content(),requestDto.requestUserId());
-        return ResponseEntity.ok(GetCommentResponseDto.from(Comment));
+        Comment comment = commentService.updateComment(id, requestDto.content(),requestDto.requestUserId());
+        return ResponseEntity.ok(GetCommentResponseDto.from(comment));
     }
 
     // 단일 삭제

--- a/src/main/java/org/sopt/comment/controller/CommentController.java
+++ b/src/main/java/org/sopt/comment/controller/CommentController.java
@@ -1,0 +1,65 @@
+package org.sopt.comment.controller;
+
+import org.sopt.comment.domain.Comment;
+import org.sopt.comment.dto.request.PostCommentRequestDto;
+import org.sopt.comment.dto.request.UpdateCommentRequestDto;
+import org.sopt.comment.dto.response.GetCommentResponseDto;
+import org.sopt.comment.service.CommentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/comment")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    public CommentController(CommentService commentService) {
+        this.commentService = commentService;
+    }
+
+    // 댓글 생성
+    @PostMapping
+    public ResponseEntity<GetCommentResponseDto> createComment(@RequestBody PostCommentRequestDto requestDto) {
+        Comment Comment = commentService.createComment(requestDto);
+        return ResponseEntity.ok(GetCommentResponseDto.from(Comment));
+    }
+
+    // 단일 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<GetCommentResponseDto> getComment(@PathVariable Long id) {
+        Comment Comment = commentService.findCommentById(id);
+        return ResponseEntity.ok(GetCommentResponseDto.from(Comment));
+    }
+
+    // 글 아이디 기준으로 전체 조회
+    @GetMapping("/all")
+    public ResponseEntity<List<GetCommentResponseDto>> getAllComments(@RequestParam Long postId) {
+        List<GetCommentResponseDto> comments = commentService.findAllCommentsByPostId(postId)
+                .stream()
+                .map(GetCommentResponseDto::from)
+                .toList();
+        return ResponseEntity.ok(comments);
+    }
+
+    // 단일 수정
+    @PatchMapping("/{id}")
+    public ResponseEntity<GetCommentResponseDto> updateComment(@RequestBody UpdateCommentRequestDto requestDto,
+                                                               @PathVariable Long id) {
+        Comment Comment = commentService.updateComment(id, requestDto.content(),requestDto.requestUserId());
+        return ResponseEntity.ok(GetCommentResponseDto.from(Comment));
+    }
+
+    // 단일 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable Long id,
+            @RequestParam Long userId
+    ) {
+        commentService.deleteComment(id, userId);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/org/sopt/comment/domain/Comment.java
+++ b/src/main/java/org/sopt/comment/domain/Comment.java
@@ -16,4 +16,13 @@ public class Comment {
     private String content;
     private LocalDate created;
     private CommentStatus commentStatus;
+
+    public void setStatusDeleted(){
+        commentStatus = CommentStatus.DELETED;
+    }
+
+
+    public void setContent(String content){
+        this.content = content;
+    }
 }

--- a/src/main/java/org/sopt/comment/domain/Comment.java
+++ b/src/main/java/org/sopt/comment/domain/Comment.java
@@ -1,0 +1,19 @@
+package org.sopt.comment.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class Comment {
+    private Long id;
+    private Long postId;
+    private Long authorId;
+    private String content;
+    private LocalDate created;
+    private CommentStatus commentStatus;
+}

--- a/src/main/java/org/sopt/comment/domain/CommentStatus.java
+++ b/src/main/java/org/sopt/comment/domain/CommentStatus.java
@@ -1,0 +1,6 @@
+package org.sopt.comment.domain;
+
+public enum CommentStatus {
+    POSTED,
+    DELETED
+}

--- a/src/main/java/org/sopt/comment/dto/request/PostCommentRequestDto.java
+++ b/src/main/java/org/sopt/comment/dto/request/PostCommentRequestDto.java
@@ -1,0 +1,8 @@
+package org.sopt.comment.dto.request;
+
+public record PostCommentRequestDto(
+        Long postId,
+        Long authorId,
+        String content
+) {
+}

--- a/src/main/java/org/sopt/comment/dto/request/UpdateCommentRequestDto.java
+++ b/src/main/java/org/sopt/comment/dto/request/UpdateCommentRequestDto.java
@@ -1,0 +1,7 @@
+package org.sopt.comment.dto.request;
+
+public record UpdateCommentRequestDto (
+        Long requestUserId,
+        String content
+){
+}

--- a/src/main/java/org/sopt/comment/dto/response/GetCommentResponseDto.java
+++ b/src/main/java/org/sopt/comment/dto/response/GetCommentResponseDto.java
@@ -1,0 +1,22 @@
+package org.sopt.comment.dto.response;
+
+import org.sopt.comment.domain.Comment;
+
+public record GetCommentResponseDto (
+        Long commentId,
+        Long postId,
+        Long authorId,
+        String content,
+        String created
+){
+    public static GetCommentResponseDto from(Comment comment) {
+        return new GetCommentResponseDto(
+                comment.getId(),
+                comment.getPostId(),
+                comment.getAuthorId(),
+                comment.getContent(),
+                comment.getCreated().toString()
+        );
+    }
+
+}

--- a/src/main/java/org/sopt/comment/repository/CommentRepository.java
+++ b/src/main/java/org/sopt/comment/repository/CommentRepository.java
@@ -1,0 +1,27 @@
+package org.sopt.comment.repository;
+
+import org.sopt.comment.domain.Comment;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Repository
+public class CommentRepository {
+
+    private static final Map<Long, Comment> store = new HashMap<>();
+
+    public Comment save(Comment comment) {
+        store.put(comment.getId(), comment);
+        return comment;
+    }
+
+    public Optional<Comment> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    public List<Comment> findByPostId(Long postId) {
+        return store.values().stream()
+                .filter(comment -> comment.getPostId().equals(postId))
+                .toList();
+    }
+}

--- a/src/main/java/org/sopt/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/comment/service/CommentService.java
@@ -1,0 +1,18 @@
+package org.sopt.comment.service;
+
+import org.sopt.comment.domain.Comment;
+import org.sopt.comment.dto.request.PostCommentRequestDto;
+
+import java.util.List;
+
+public interface CommentService {
+    Comment createComment(PostCommentRequestDto requestDto);
+
+    Comment findCommentById(Long id);
+
+    List<Comment> findAllCommentsByPostId(Long postId);
+
+    Comment updateComment(Long commentId, String content, Long requestUserId);
+
+    void deleteComment(Long commentId, Long requestUserId);
+}

--- a/src/main/java/org/sopt/comment/service/CommentServiceImpl.java
+++ b/src/main/java/org/sopt/comment/service/CommentServiceImpl.java
@@ -1,0 +1,102 @@
+package org.sopt.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.comment.domain.Comment;
+import org.sopt.comment.domain.CommentStatus;
+import org.sopt.comment.dto.request.PostCommentRequestDto;
+import org.sopt.article.repository.ArticleRepository;
+import org.sopt.comment.repository.CommentRepository;
+import org.sopt.common.exception.CustomException;
+import org.sopt.common.exception.ErrorCode;
+import org.sopt.common.validator.Validator;
+import org.sopt.member.repository.MemoryMemberRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final ArticleRepository articleRepository;
+    private final MemoryMemberRepository memoryMemberRepository;
+    private static long sequence = 1L;
+
+    @Override
+    public Comment createComment(PostCommentRequestDto requestDto) {
+        validateCommentCreation(requestDto.postId(), requestDto.authorId(), requestDto.content());
+
+
+        Comment comment = Comment.builder()
+                .id(sequence++)
+                .commentStatus(CommentStatus.POSTED)
+                .postId(requestDto.postId())
+                .content(requestDto.content())
+                .authorId(requestDto.authorId())
+                .created(LocalDate.from(LocalDateTime.now()))
+                .build();
+
+        commentRepository.save(comment);
+        return comment;
+    }
+
+
+    @Override
+    public Comment findCommentById(Long id) {
+        return commentRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+    }
+
+    @Override
+    public List<Comment> findAllCommentsByPostId(Long postId) {
+        return commentRepository.findByPostId(postId).stream().toList();
+    }
+
+    @Override
+    public Comment updateComment(Long commentId, String content, Long requestUserId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+        Validator.validateCommentLength(content);
+        validateAuthorizedUser(requestUserId, comment);
+
+        comment.setContent(content);
+        return comment;
+    }
+
+    private static void validateAuthorizedUser(Long requestUserId, Comment comment) {
+        if (!Objects.equals(comment.getAuthorId(), requestUserId)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_USER_REQUEST);
+        }
+    }
+
+    @Override
+    public void deleteComment(Long commentId, Long requestUserId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        validateAuthorizedUser(requestUserId, comment);
+
+        comment.setStatusDeleted();
+    }
+
+
+    private void validateCommentCreation(Long postId, Long userId, String content) {
+        validateCommentRequest(postId, userId);
+        Validator.validateCommentLength(content);
+
+    }
+
+    private void validateCommentRequest(Long postId, Long userId) {
+        articleRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        memoryMemberRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+    }
+
+}

--- a/src/main/java/org/sopt/common/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/common/exception/ErrorCode.java
@@ -6,6 +6,7 @@ public enum ErrorCode {
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 글을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글이 존재하지 않습니다."),
 
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
     DUPLICATE_TITLE(HttpStatus.CONFLICT, "중복된 제목입니다."),
@@ -16,8 +17,10 @@ public enum ErrorCode {
     INVALID_TITLE_INPUT(HttpStatus.BAD_REQUEST, "제목 입력 형식이 올바르지 않습니다."),
     INVALID_TAG_INPUT(HttpStatus.BAD_REQUEST, "태그 입력 값이 올바르지 않습니다."),
     INVALID_EMAIL_INPUT(HttpStatus.BAD_REQUEST, "이메일 입력 형식이 올바르지 않습니다."),
-
+    INVALID_COMMENT_LENGTH_INPUT(HttpStatus.BAD_REQUEST, "댓글 길이가 300자를 초과했습니다."),
     UNDERAGE_MEMBER(HttpStatus.BAD_REQUEST, "20세 미만은 가입할 수 없습니다."),
+
+    UNAUTHORIZED_USER_REQUEST(HttpStatus.UNAUTHORIZED, "해당 유저는 댓글 수정 및 삭제 권한이 없습니다."),
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
 

--- a/src/main/java/org/sopt/common/validator/Validator.java
+++ b/src/main/java/org/sopt/common/validator/Validator.java
@@ -6,7 +6,6 @@ import org.sopt.member.domain.Member;
 
 public class Validator {
 
-
     public static void validateEmailFormat(String email) {
         if (email == null || email.isBlank() || !email.contains("@")) {
             throw new CustomException(ErrorCode.INVALID_EMAIL_INPUT);
@@ -28,6 +27,12 @@ public class Validator {
     public static void validateTitle(String title) {
         if (title == null || title.isBlank()) {
             throw new CustomException(ErrorCode.INVALID_TITLE_INPUT);
+        }
+    }
+
+    public static void validateCommentLength(String content) {
+        if (content.length() > 300) {
+            throw new CustomException(ErrorCode.INVALID_COMMENT_LENGTH_INPUT);
         }
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*
closed #10 

## 👷 **과제 구현**

### 필수과제
- [x] 댓글 작성/수정/삭제/조회 기능구현
- [x] 댓글 제한사항 구현
- [x] 댓글 작성자 데이터를 유저 id를 저장해 유저 정보와 연결

<br>

<br>

### **구현한 내용에 대해서 설명해주세요**
- comment 기능을 위한 도메인 생성
- 추가 기능들을 위한 에러코드 추가
- 게시글 상세 조회 시 같이 조회되기 위해 기존의 게시글 상세 조회 api 리팩터링 진행
<br>


### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**
- 댓글 삭제와 관련해서는 완전 삭제보다 클라이언트에서 삭제요청을 하더라도 데이터 관리를 위해 status 필드에 POSTED, DELETED로 관리하는 것으로 구현하였습니다
- 게시글 전체 리스트 조회 api 가 기존에는 게시글 내 모든 내용을 포함하도록 responseDTO를 구성했었었는데, 댓글이 추가됨에 따라 기존의 게시글 전체 리스트 조회 api의 dto를 게시글 내용 등 불필요한 내용을 제외하고 제목, 게시된 일자, 작성자 정도의 프리뷰 데이터만 포함하도록 수정하였습니다.


<br>

---

## 🚨 참고 사항